### PR TITLE
Instanced line rendering cleanup

### DIFF
--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -441,6 +441,7 @@ void __fastcall TForm1::DrawObjects(void)
 
     AircraftCountLabel->Caption=IntToStr((int)ght_size(HashTable));
         std::vector<AirplaneInstance> planeBatch;
+        std::vector<AirplaneLineInstance> lineBatch;
         for(Data = (TADS_B_Aircraft *)ght_first(HashTable, &iterator,(const void **) &Key);
                           Data; Data = (TADS_B_Aircraft *)ght_next(HashTable, &iterator, (const void **)&Key))
         {
@@ -470,29 +471,32 @@ void __fastcall TForm1::DrawObjects(void)
 					color[0]=1.0f; color[1]=0.0f; color[2]=0.0f; color[3]=1.0f;
 				}
 
-			AirplaneInstance inst;
-			inst.x=ScrX;
-			inst.y=ScrY;
-			inst.scale=1.5f;
-			inst.heading=Data->Heading;
-			inst.imageNum=Data->SpriteImage;
-			inst.color[0]=color[0];
-			inst.color[1]=color[1];
-			inst.color[2]=color[2];
-			inst.color[3]=color[3];
-			planeBatch.push_back(inst);
 
-			glRasterPos2i(ScrX+30,ScrY-10);
-			ObjectDisplay->Draw2DText(Data->HexAddr);
+                        AirplaneInstance inst;
+                        inst.x = ScrX;
+                        inst.y = ScrY;
+                        inst.scale = 1.5f;
+                        inst.heading = Data->Heading;
+                        inst.imageNum = Data->SpriteImage;
+                        inst.color[0] = color[0];
+                        inst.color[1] = color[1];
+                        inst.color[2] = color[2];
+                        inst.color[3] = color[3];
+                        planeBatch.push_back(inst);
 
-			glColor4f(1.0, 1.0, 0.0, 1.0);
-			glBegin(GL_LINE_STRIP);
-			glVertex2f(ScrX,ScrY);
-			glVertex2f(ScrX2,ScrY2);
-			glEnd();
+                        AirplaneLineInstance line;
+                        line.x1 = ScrX;
+                        line.y1 = ScrY;
+                        line.x2 = ScrX2;
+                        line.y2 = ScrY2;
+                        lineBatch.push_back(line);
+
+                        glRasterPos2i(ScrX+30,ScrY-10);
+                        ObjectDisplay->Draw2DText(Data->HexAddr);
         }
        }
         DrawAirplaneImagesInstanced(planeBatch);
+        DrawAirplaneLinesInstanced(lineBatch);
  ViewableAircraftCountLabel->Caption=ViewableAircraft;
  if (TrackHook.Valid_CC)
  {

--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -334,7 +334,7 @@ void __fastcall TForm1::Timer1Timer(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TForm1::DrawObjects(void)
 {
-  double ScrX, ScrY;
+  double ScrX, ScrY, ScrX2, ScrY2;
   int    ViewableAircraft=0;
 
   glEnable( GL_LINE_SMOOTH );
@@ -449,48 +449,47 @@ void __fastcall TForm1::DrawObjects(void)
                 ViewableAircraft++;
 
            LatLon2XY(Data->Latitude,Data->Longitude, ScrX, ScrY);
+		   ScrX2 = ScrX;
+		   ScrY2 = ScrY;
            //DrawPoint(ScrX,ScrY);
            float color[4] = {1.0f, 1.0f, 1.0f, 1.0f};
            if (Data->HaveSpeedAndHeading)
            {
                  color[0]=1.0f; color[1]=0.0f; color[2]=1.0f; color[3]=1.0f;
-           }
-           else
-                {
-                 Data->Heading=0.0;
-                 color[0]=1.0f; color[1]=0.0f; color[2]=0.0f; color[3]=1.0f;
-                }
+				 if (TimeToGoCheckBox->State==cbChecked)
+				 {
+					double lat2,lon2,az2;
+					VDirect(Data->Latitude,Data->Longitude,
+							Data->Heading,Data->Speed*(double)TimeToGoTrackBar->Position/3600.0,&lat2,&lon2,&az2);
+					LatLon2XY(lat2,lon2, ScrX2, ScrY2);
+					}
+			}
+			else
+				{
+					Data->Heading=0.0;
+					color[0]=1.0f; color[1]=0.0f; color[2]=0.0f; color[3]=1.0f;
+				}
 
-           AirplaneInstance inst;
-           inst.x=ScrX;
-           inst.y=ScrY;
-           inst.scale=1.5f;
-           inst.heading=Data->Heading;
-           inst.imageNum=Data->SpriteImage;
-           inst.color[0]=color[0];
-           inst.color[1]=color[1];
-           inst.color[2]=color[2];
-           inst.color[3]=color[3];
-           planeBatch.push_back(inst);
+			AirplaneInstance inst;
+			inst.x=ScrX;
+			inst.y=ScrY;
+			inst.scale=1.5f;
+			inst.heading=Data->Heading;
+			inst.imageNum=Data->SpriteImage;
+			inst.color[0]=color[0];
+			inst.color[1]=color[1];
+			inst.color[2]=color[2];
+			inst.color[3]=color[3];
+			planeBatch.push_back(inst);
 
-           glRasterPos2i(ScrX+30,ScrY-10);
-           ObjectDisplay->Draw2DText(Data->HexAddr);
+			glRasterPos2i(ScrX+30,ScrY-10);
+			ObjectDisplay->Draw2DText(Data->HexAddr);
 
-	   if ((Data->HaveSpeedAndHeading) && (TimeToGoCheckBox->State==cbChecked))
-	   {
-		double lat,lon,az;
-		if (VDirect(Data->Latitude,Data->Longitude,
-					Data->Heading,Data->Speed*(double)TimeToGoTrackBar->Position/3600.0,&lat,&lon,&az)==OKNOERROR)
-		  {
-			 double ScrX2, ScrY2;
-			 LatLon2XY(lat,lon, ScrX2, ScrY2);
-             glColor4f(1.0, 1.0, 0.0, 1.0);
-			 glBegin(GL_LINE_STRIP);
-			 glVertex2f(ScrX,ScrY);
-			 glVertex2f(ScrX2,ScrY2);
-			 glEnd();
-		  }
-	   }
+			glColor4f(1.0, 1.0, 0.0, 1.0);
+			glBegin(GL_LINE_STRIP);
+			glVertex2f(ScrX,ScrY);
+			glVertex2f(ScrX2,ScrY2);
+			glEnd();
         }
        }
         DrawAirplaneImagesInstanced(planeBatch);

--- a/ntds2d.cpp
+++ b/ntds2d.cpp
@@ -45,7 +45,16 @@ struct InstancingResources {
     GLuint program;
 };
 
-static InstancingResources gInstancing = {false};
+struct LineInstancingResources {
+    bool initialized;
+    GLuint vao;
+    GLuint vertexVBO;
+    GLuint instanceVBO;
+    GLuint program;
+};
+
+static InstancingResources gInstancing = {false,0,0,0,0};
+static LineInstancingResources gLineInstancing = {false,0,0,0,0};
 
 // OpenGL extension function pointers for systems with only GL 1.1 headers
 static bool gExtensionsLoaded = false;
@@ -439,6 +448,7 @@ void InitAirplaneInstancing()
 
     gInstancing.program = CreateProgram(vsSrc, fsSrc);
 
+
     float quad[] = {
         1.0f, 1.0f, 1.0f, 1.0f,
        -1.0f, 1.0f, 0.0f, 1.0f,
@@ -484,6 +494,56 @@ void InitAirplaneInstancing()
     gInstancing.initialized = true;
 }
 
+void InitAirplaneLinesInstancing()
+{
+    LoadGLExtensions();
+    const char* vsSrc =
+        "#version 330 core\n"
+        "layout(location=0) in float t;\n"
+        "layout(location=1) in vec2 start;\n"
+        "layout(location=2) in vec2 end;\n"
+        "uniform vec2 Viewport;\n"
+        "void main(){\n"
+        "  vec2 p = mix(start, end, t);\n"
+        "  vec2 ndc = vec2((p.x/Viewport.x)*2.0 - 1.0, (p.y/Viewport.y)*2.0 - 1.0);\n"
+        "  gl_Position = vec4(ndc,0.0,1.0);\n"
+        "}\n";
+
+    const char* fsSrc =
+        "#version 330 core\n"
+        "out vec4 Frag;\n"
+        "void main(){ Frag = vec4(1.0,1.0,0.0,1.0); }\n";
+
+    gLineInstancing.program = CreateProgram(vsSrc, fsSrc);
+
+    float verts[] = {0.0f, 1.0f};
+    pglGenVertexArrays(1, &gLineInstancing.vao);
+    pglBindVertexArray(gLineInstancing.vao);
+
+    pglGenBuffers(1, &gLineInstancing.vertexVBO);
+    pglBindBuffer(GL_ARRAY_BUFFER, gLineInstancing.vertexVBO);
+    pglBufferData(GL_ARRAY_BUFFER, sizeof(verts), verts, GL_STATIC_DRAW);
+    pglEnableVertexAttribArray(0);
+    pglVertexAttribPointer(0, 1, GL_FLOAT, GL_FALSE, sizeof(float), (void*)0);
+
+    pglGenBuffers(1, &gLineInstancing.instanceVBO);
+    pglBindBuffer(GL_ARRAY_BUFFER, gLineInstancing.instanceVBO);
+    pglBufferData(GL_ARRAY_BUFFER, 0, NULL, GL_STREAM_DRAW);
+
+    size_t stride = sizeof(AirplaneLineInstance);
+    pglEnableVertexAttribArray(1);
+    pglVertexAttribPointer(1, 2, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneLineInstance, x1));
+    pglVertexAttribDivisor(1,1);
+    pglEnableVertexAttribArray(2);
+    pglVertexAttribPointer(2, 2, GL_FLOAT, GL_FALSE, stride, (void*)offsetof(AirplaneLineInstance, x2));
+    pglVertexAttribDivisor(2,1);
+
+    pglBindBuffer(GL_ARRAY_BUFFER, 0);
+    pglBindVertexArray(0);
+
+    gLineInstancing.initialized = true;
+}
+
 void DrawAirplaneImagesInstanced(const std::vector<AirplaneInstance>& instances)
 {
     if(instances.empty()) return;
@@ -505,6 +565,27 @@ void DrawAirplaneImagesInstanced(const std::vector<AirplaneInstance>& instances)
     pglDrawArraysInstanced(GL_TRIANGLE_FAN, 0, 4, instances.size());
 
     glBindTexture(GL_TEXTURE_2D_ARRAY, 0);
+    pglBindVertexArray(0);
+    pglUseProgram(0);
+}
+
+void DrawAirplaneLinesInstanced(const std::vector<AirplaneLineInstance>& instances)
+{
+    if(instances.empty()) return;
+    if(!gLineInstancing.initialized)
+        InitAirplaneLinesInstancing();
+
+    pglBindVertexArray(gLineInstancing.vao);
+    pglBindBuffer(GL_ARRAY_BUFFER, gLineInstancing.instanceVBO);
+    pglBufferData(GL_ARRAY_BUFFER, instances.size()*sizeof(AirplaneLineInstance), instances.data(), GL_STREAM_DRAW);
+
+    pglUseProgram(gLineInstancing.program);
+    GLint vp[4];
+    glGetIntegerv(GL_VIEWPORT, vp);
+    pglUniform2f(pglGetUniformLocation(gLineInstancing.program, "Viewport"), (float)vp[2], (float)vp[3]);
+    glLineWidth(3.0f);
+    pglDrawArraysInstanced(GL_LINES, 0, 2, instances.size());
+
     pglBindVertexArray(0);
     pglUseProgram(0);
 }

--- a/ntds2d.h
+++ b/ntds2d.h
@@ -22,8 +22,17 @@ struct AirplaneInstance {
     int   imageNum;
     float color[4];
 };
+
+struct AirplaneLineInstance {
+    float x1;
+    float y1;
+    float x2;
+    float y2;
+};
 void InitAirplaneInstancing();
 void DrawAirplaneImagesInstanced(const std::vector<AirplaneInstance>& instances);
+void InitAirplaneLinesInstancing();
+void DrawAirplaneLinesInstanced(const std::vector<AirplaneLineInstance>& instances);
 void DrawTrackHook(float x, float y);
 void DrawRadarCoverage(float xc, float yc, float major, float minor);
 void DrawLeader(float x1, float y1, float x2, float y2);


### PR DESCRIPTION
## Summary
- separate leader line data into new `AirplaneLineInstance` structure
- add dedicated instancing path with `InitAirplaneLinesInstancing` and `DrawAirplaneLinesInstanced`
- batch leader lines in `DisplayGUI` using the new API

## Testing
- `g++ -c ntds2d.cpp -std=c++11 -DGL_GLEXT_PROTOTYPES` *(fails: `windows.h` not found)*
- `g++ -c DisplayGUI.cpp -std=c++11 -DGL_GLEXT_PROTOTYPES` *(fails: `vcl.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc9e9bfc8832d877076323986bc4c