### PR TITLE
Optimize hex address rendering

### DIFF
--- a/Aircraft.h
+++ b/Aircraft.h
@@ -3,6 +3,7 @@
 #ifndef AircraftH
 #define AircraftH
 #include "DecodeRawADS_B.h"
+#include <GL/gl.h>
 
 #define MODES_NON_ICAO_ADDRESS       (1<<24) // Set on addresses to indicate they are not ICAO addresses
 
@@ -31,6 +32,7 @@ typedef struct
  double              Speed;
  double              VerticalRate;
  int                 SpriteImage;
+ GLuint              HexDisplayList;
 } TADS_B_Aircraft;
 
 

--- a/DisplayGUI.cpp
+++ b/DisplayGUI.cpp
@@ -9,6 +9,8 @@
 #include <stdlib.h>
 #include <filesystem>
 #include <fileapi.h>
+#include <unordered_map>
+#include <string>
 
 
 #pragma hdrstop
@@ -107,6 +109,25 @@ uint32_t PopularColors[] = {
    };
 
 }TMultiColor;
+
+static std::unordered_map<std::string, GLuint> HexAddrDisplayLists;
+static GLuint GetHexAddrDisplayList(TOpenGLPanel* panel, const char* addr)
+{
+    auto it = HexAddrDisplayLists.find(addr);
+    if(it != HexAddrDisplayLists.end())
+        return it->second;
+
+    GLuint list = glGenLists(1);
+    if(list == 0)
+        return 0;
+
+    glNewList(list, GL_COMPILE);
+    panel->Draw2DText(addr);
+    glEndList();
+
+    HexAddrDisplayLists[addr] = list;
+    return list;
+}
 
 
 //---------------------------------------------------------------------------
@@ -493,8 +514,10 @@ void __fastcall TForm1::DrawObjects(void)
 				line.y2 = ScrY2;
 				m_lineBatch.push_back(line);
 
-				glRasterPos2i(ScrX+30,ScrY-10);
-				ObjectDisplay->Draw2DText(Data->HexAddr);
+                                glRasterPos2i(ScrX+30,ScrY-10);
+                                GLuint txtList = GetHexAddrDisplayList(ObjectDisplay, Data->HexAddr);
+                                if(txtList)
+                                    glCallList(txtList);
         }
 	   }
 		DrawAirplaneLinesInstanced(m_lineBatch);

--- a/SBS_Message.cpp
+++ b/SBS_Message.cpp
@@ -299,9 +299,10 @@ bool SBS_Message_Decode( char *msg)
          ADS_B_Aircraft->HaveAltitude=false;
          ADS_B_Aircraft->HaveLatLon=false;
          ADS_B_Aircraft->HaveSpeedAndHeading=false;
-         ADS_B_Aircraft->HaveFlightNum=false;
-         ADS_B_Aircraft->SpriteImage=Form1->CurrentSpriteImage;
-         if (Form1->CycleImages->Checked)
+        ADS_B_Aircraft->HaveFlightNum=false;
+        ADS_B_Aircraft->SpriteImage=Form1->CurrentSpriteImage;
+        ADS_B_Aircraft->HexDisplayList=0;
+        if (Form1->CycleImages->Checked)
               Form1->CurrentSpriteImage=(Form1->CurrentSpriteImage+1)%Form1->NumSpriteImages;
 		 if (ght_insert(Form1->HashTable,ADS_B_Aircraft,sizeof(addr), &addr) < 0)
              {


### PR DESCRIPTION
## Summary
- add cache for ICAO hex address text
- draw cached display list instead of repeatedly rendering strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684de44ccff4832daf050f84687c29ad